### PR TITLE
clusterContigs now properly instantiates LinkageGroupList, so mergeLi…

### DIFF
--- a/R/clusterContigs.R
+++ b/R/clusterContigs.R
@@ -129,6 +129,7 @@ clusterContigs.func <- function(object, #heatFile from contiBAIT; a data frame c
 		}
 	}
 	
+  linkageGroups <- new('LinkageGroupList', linkageGroup)
 	return(linkageGroups)
 }
 


### PR DESCRIPTION
…nkageGroups won't crash anymore.
