### PR TITLE
More faster ordering

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -95,7 +95,8 @@ setGeneric("orderAllLinkageGroups",
             		whichLG=NULL, 
             		saveOrdered=NULL, 
             		orderCall=NULL, 
-            		randomAttempts=NULL, 
+            		randomAttempts=NULL,
+            		nProcesses = 1,
             		verbose=NULL) standardGeneric("orderAllLinkageGroups"),
 		   signature=c('linkageGroupList', 'strandStateMatrix','strandFreqMatrix', 'strandReadCount' ))
 

--- a/R/orderAllLinkageGroups.R
+++ b/R/orderAllLinkageGroups.R
@@ -5,7 +5,8 @@ orderAllLinkageGroups.func <- function(linkageGroupList,
                                        whichLG=NULL, 
                                        saveOrdered=NULL, 
                                        orderCall='greedy', 
-                                       randomAttempts=75, 
+                                       randomAttempts=75,
+                                       nProcesses = 1,
                                        verbose=TRUE)
 {
 
@@ -105,7 +106,7 @@ orderAllLinkageGroups.func <- function(linkageGroupList,
       #Choose which ordering method to use
       if(orderCall == 'greedy')
       {
-        outOfOrder <- orderContigsGreedy(linkageGroupReadTable, randomAttempts=randomAttempts)
+        outOfOrder <- orderContigsGreedy(linkageGroupReadTable, randomAttempts=randomAttempts,nProcesses = nProcesses,verbose=verbose)
       }else if (orderCall == 'TSP')
       {
         outOfOrder <- orderContigsTSP(linkageGroupReadTable, reps=randomAttempts)
@@ -143,8 +144,10 @@ orderAllLinkageGroups.func <- function(linkageGroupList,
                                       Colv=NA, 
                                       dendrogram="none", 
                                       revC=TRUE, 
-                                      col=cols(100), 
-                                      breaks=breaks, 
+                                      col=colorRampPalette(c("#f7fcfd", "#00441b"))(n=9), 
+                                      # breaks=breaks, 
+                                      labRow = "",
+                                      labCol = "",
                                       trace='none', 
                                       main=paste(orderCall, '-ordered LG', whichLG[lg], '\n main fragment: ', names(chromosome), ' (', chromosome, '%)', sep="")))
          }
@@ -188,6 +191,7 @@ orderAllLinkageGroups.func <- function(linkageGroupList,
 #' @param orderCall currently either 'greedy' for greedy algorithm or 'TSP' for travelling salesperson alogrithm (default is 'greedy')
 #' @param verbose Pringts messages to the terminal. Default is TRUE
 #' @param randomAttempts itenger specifying number of iterations of either the Monte Carlo or the 2-opt TSP solver to identify the best ordering. Default is 75, but higher values (eg 1000) make more sense for the TSP.
+#' @param nProcesses number of processes to attempt ordering in parallel
 #' @aliases orderAllLinkageGroups orderAllLinkageGroups,orderAllLinkageGroups-LinkageGroupList-StrandStateMatrix-StrandFreqMatrix-StrandReadMatrix-method
 #' @rdname orderAllLinkageGroups
 #' 

--- a/R/orderAllLinkageGroups.R
+++ b/R/orderAllLinkageGroups.R
@@ -137,15 +137,12 @@ orderAllLinkageGroups.func <- function(linkageGroupList,
 
          if(nrow(similarLinkageStrands) > 1)
          {
-           breaks <- seq(0, 100, length.out=101)/100 
-           cols <- colorRampPalette(c("cyan", "blue", "grey30", "black", "grey30", "red", "orange"))
-           suppressWarnings(heatmap.2(similarLinkageStrands, 
+          suppressWarnings(heatmap.2(similarLinkageStrands, 
                                       Rowv=NA, 
                                       Colv=NA, 
                                       dendrogram="none", 
                                       revC=TRUE, 
                                       col=colorRampPalette(c("#f7fcfd", "#00441b"))(n=9), 
-                                      # breaks=breaks, 
                                       labRow = "",
                                       labCol = "",
                                       trace='none', 

--- a/R/orderContigsGreedy.R
+++ b/R/orderContigsGreedy.R
@@ -57,7 +57,6 @@ orderContigsGreedy <- function(linkageGroupReadTable, randomAttempts=75,nProcess
       for (i in res[-1]){
         if (i[[3]] < best_order[[3]])
         {
-          print(paste(best_order[[3]],i[[3]],sep=' replaced by'))
           best_order <<- i
         }
         

--- a/R/orderContigsGreedy.R
+++ b/R/orderContigsGreedy.R
@@ -30,7 +30,7 @@ orderContigsGreedy <- function(linkageGroupReadTable, randomAttempts=75, verbose
       temp_table <- as.matrix(linkageGroupReadTable[sample(nrow(linkageGroupReadTable)),])
       temp_order <- .Call('orderContigsGreedy', temp_table)
 
-      if ( temp_order$score > best_order$score){
+      if ( temp_order$score < best_order$score){
         if(verbose){message('     -> Found better ordering!')}  
         best_order <- temp_order
         best_table <- temp_table

--- a/R/orderContigsGreedy.R
+++ b/R/orderContigsGreedy.R
@@ -6,12 +6,13 @@
 # 
 #' @param linkageGroupReadTable dataframe of strand calls (product of combineZeroDists or preprocessStrandTable)
 #' @param randomAttempts number of times to repeat the greedy algortihm with a random restart
+#' @param nProcesses number of processes to attempt ordering in parallel
 #' @param verbose whether to print verbose messages
 #' @return list of two members: 1) contig names in order, 2) the original data.frame entered into function correctly ordered  
 ####################################################################################################
 
 
-orderContigsGreedy <- function(linkageGroupReadTable, randomAttempts=75, verbose=TRUE)
+orderContigsGreedy <- function(linkageGroupReadTable, randomAttempts=75,nProcesses = 1, verbose=TRUE)
 {  
   factorizedLinkageGroupReadTable <- linkageGroupReadTable
 
@@ -22,25 +23,52 @@ orderContigsGreedy <- function(linkageGroupReadTable, randomAttempts=75, verbose
 
   if(nrow(linkageGroupReadTable) > 1)
   {
-    best_order <- .Call('orderContigsGreedy', as.matrix(linkageGroupReadTable))
-    best_table <- linkageGroupReadTable
-
-    for (i in seq_len(randomAttempts)) {
-      #temp_order <- list(order = 1:length(linkageGroup),score = 0)
-      temp_table <- as.matrix(linkageGroupReadTable[sample(nrow(linkageGroupReadTable)),])
-      temp_order <- .Call('orderContigsGreedy', temp_table)
-
-      if ( temp_order$score < best_order$score){
-        if(verbose){message('     -> Found better ordering!')}  
-        best_order <- temp_order
-        best_table <- temp_table
+    order_contigs <- function(linkageGroupReadTable,randomAttempts,verbose,factorizedLinkageGroupReadTable)
+    {
+      best_order <- .Call('orderContigsGreedy', as.matrix(linkageGroupReadTable))
+      best_table <- linkageGroupReadTable
+      
+      
+      for (i in seq_len(randomAttempts)) {
+        #temp_order <- list(order = 1:length(linkageGroup),score = 0)
+        temp_table <- as.matrix(linkageGroupReadTable[sample(nrow(linkageGroupReadTable)),])
+        temp_order <- .Call('orderContigsGreedy', temp_table)
+        
+        if ( temp_order$score < best_order$score){
+          if(verbose){message('     -> Found better ordering!')}  
+          best_order <- temp_order
+          best_table <- temp_table
+        }
       }
+      
+      linkageGroupReadTable <- factorizedLinkageGroupReadTable[row.names(best_table)[best_order$order],]
+      return(c(list(orderVector=row.names(best_table)[best_order$order], orderedMatrix=linkageGroupReadTable),best_order$score))
     }
-
-  linkageGroupReadTable <- factorizedLinkageGroupReadTable[row.names(best_table)[best_order$order],]
-  return(list(orderVector=row.names(best_table)[best_order$order], orderedMatrix=linkageGroupReadTable))
-
-  }else{
+    if (nProcesses > 1)
+    {
+      cl <- makeCluster(getOption("cl.cores",nProcesses))
+      
+      
+      clusterExport(cl,'contiBAIT')
+      res <- clusterCall(cl,order_contigs,linkageGroupReadTable,randomAttempts,verbose,factorizedLinkageGroupReadTable)
+      
+      stopCluster(cl)
+      best_order <- res[[1]]
+      for (i in res[-1]){
+        if (i[[3]] < best_order[[3]])
+        {
+          print(paste(best_order[[3]],i[[3]],sep=' replaced by'))
+          best_order <<- i
+        }
+        
+      }
+      return(best_order[-3])
+    } else
+    {
+      return(order_contigs(linkageGroupReadTable,randomAttempts,verbose,factorizedLinkageGroupReadTable)[-3])
+    }
+  }else
+  {
     linkageGroupReadTable <- factorizedLinkageGroupReadTable
     return(list(orderVector=row.names(linkageGroupReadTable), orderedMatrix=linkageGroupReadTable))
   }

--- a/man/orderAllLinkageGroups.Rd
+++ b/man/orderAllLinkageGroups.Rd
@@ -11,7 +11,7 @@
   \S4method{orderAllLinkageGroups}{LinkageGroupList,StrandStateMatrix,StrandFreqMatrix,StrandReadMatrix}(linkageGroupList,
   strandStateMatrix, strandFreqMatrix, strandReadCount, whichLG = NULL,
   saveOrdered = NULL, orderCall = "greedy", randomAttempts = 75,
-  verbose = TRUE)
+  nProcesses = 1, verbose = TRUE)
 }
 \arguments{
 \item{linkageGroupList}{list of vectors, each specifying which contigs belong in which linkage group (product of clusterContigs)}
@@ -29,6 +29,8 @@
 \item{orderCall}{currently either 'greedy' for greedy algorithm or 'TSP' for travelling salesperson alogrithm (default is 'greedy')}
 
 \item{randomAttempts}{itenger specifying number of iterations of either the Monte Carlo or the 2-opt TSP solver to identify the best ordering. Default is 75, but higher values (eg 1000) make more sense for the TSP.}
+
+\item{nProcesses}{number of processes to attempt ordering in parallel}
 
 \item{verbose}{Pringts messages to the terminal. Default is TRUE}
 }

--- a/man/orderContigsGreedy.Rd
+++ b/man/orderContigsGreedy.Rd
@@ -6,12 +6,14 @@
 Attempt to order contigs within}
 \usage{
 orderContigsGreedy(linkageGroupReadTable, randomAttempts = 75,
-  verbose = TRUE)
+  nProcesses = 1, verbose = TRUE)
 }
 \arguments{
 \item{linkageGroupReadTable}{dataframe of strand calls (product of combineZeroDists or preprocessStrandTable)}
 
 \item{randomAttempts}{number of times to repeat the greedy algortihm with a random restart}
+
+\item{nProcesses}{number of processes to attempt ordering in parallel}
 
 \item{verbose}{whether to print verbose messages}
 }


### PR DESCRIPTION
@oneillkza @rareaquaticbadger @matthewborkowski
Default behaviour unchanged.

Fixed bug that resulted in verbose flag being ignored in
orderAllLinkageGroups.

Cleaned up contig order plot by removing illegible row and column labels.
Changed colour scheme so that it uses a sequential rather than
diverging colour scale and reduced the number of breaks to a more
perceptible quantity.

This includes Matt's performance improvements to orderContigsGreedy.cpp. From our
testing this reduces run time of a single random ordering attempt on the
first Tasmanian devil linkage group from ~7 minutes to ~6 seconds. With
the added multiprocessing it is now possible to do many many more ordering
attempts.
